### PR TITLE
Remove dependency on thor

### DIFF
--- a/knife-inspect.gemspec
+++ b/knife-inspect.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
 
-  s.add_runtime_dependency "thor"
   s.add_runtime_dependency "chef", chef_version
   s.add_runtime_dependency "yajl-ruby"
 end


### PR DESCRIPTION
It has been removed in 3d86962 when it became a knife plugin and renamed to
knife-inspect.
