### PR TITLE
Make output not use unicode when stdout is not a TTY.

### DIFF
--- a/lib/health_inspector/checklists/base.rb
+++ b/lib/health_inspector/checklists/base.rb
@@ -78,7 +78,11 @@ module HealthInspector
       end
 
       def print_success(subject)
-        ui.msg color('bright pass', '✓') + " #{subject}"
+        if $stdout.tty?
+          ui.msg color('bright pass', "✓") + " #{subject}"
+        else
+          ui.msg "Success #{subject}"
+        end
       end
 
       def print_failures(subject, failures)


### PR DESCRIPTION
When using with Jenkins (etc), rather than fight it's UTF8/Unicode
support, just print the word "succees" rather the much cooler '✓'.

Yes, you could remove all the colours everywhere else too.
