### PR TITLE
Improve local role handling

### DIFF
--- a/spec/chef-repo/roles/role_one.json
+++ b/spec/chef-repo/roles/role_one.json
@@ -1,0 +1,3 @@
+{
+    "name": "role_one"
+}

--- a/spec/chef-repo/roles/role_two.rb
+++ b/spec/chef-repo/roles/role_two.rb
@@ -1,0 +1,1 @@
+name 'role_two'

--- a/spec/chef-repo/roles/subdir/role_from_subdir.json
+++ b/spec/chef-repo/roles/subdir/role_from_subdir.json
@@ -1,0 +1,3 @@
+{
+    "name": "role_from_subdir"
+}

--- a/spec/health_inspector/checklists/roles_spec.rb
+++ b/spec/health_inspector/checklists/roles_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe HealthInspector::Checklists::Roles do
         'role_two'         => 'url',
         'role_from_subdir' => 'url'
       )
-      expect(checklist.server_items.sort)
+      expect(checklist.server_items.keys.sort)
         .to eq %w(role_from_subdir role_one role_two)
     end
   end
 
   describe '#local_items' do
     it 'returns a list of roles from the chef repo' do
-      expect(checklist.local_items.sort)
+      expect(checklist.local_items.keys.sort)
         .to eq %w(role_from_subdir role_one role_two)
     end
   end


### PR DESCRIPTION
- allow role filename to be different than role.name
- test json and rb role files

This patch mimic the Chef::Role.from_disk method which unable to read in
subdir (how sad!)