### PR TITLE
Allow to deactivate inspection by component

### DIFF
--- a/lib/chef/knife/inspect.rb
+++ b/lib/chef/knife/inspect.rb
@@ -13,8 +13,20 @@ class Chef
 
       banner 'knife inspect'
 
+      CHECKLISTS.map do |checklist|
+        opt_name = checklist.downcase.to_sym
+        option opt_name,
+          :long => "--[no-]#{opt_name}",
+          :boolean => true,
+          :default => true,
+          :description => "Add or exclude #{opt_name} from inspection"
+      end
+
       def run
-        results = CHECKLISTS.map do |checklist|
+        results = CHECKLISTS.select do |checklist|
+          opt_name = checklist.downcase.to_sym
+          config[opt_name] or config[opt_name].nil?
+        end.map do |checklist|
           HealthInspector::Checklists.const_get(checklist).run(self)
         end
 


### PR DESCRIPTION
By default, knife inspect treats all components (role, cookbooks, env)
Using --no-cookbooks will make it skip cookbook inspection