### PR TITLE
Fixed Chef::Exceptions::InvalidCookbookVersion errors

### DIFF
--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -1,7 +1,7 @@
 require 'chef/version'
 require 'chef/cookbook_version'
 require 'chef/cookbook_loader'
-require 'chef/checksum_cache' if Chef::Version.new(Chef::VERSION) < Chef::Version.new('11.0.0')
+require 'chef/checksum_cache' if Gem::Version.new(Chef::VERSION) < Gem::Version.new('11.0.0')
 
 module HealthInspector
   module Checklists


### PR DESCRIPTION
When using some chef .gems (such as 11.18.0) knife-inspect causes an
except to be thrown.

This is because `Chef::Version` is only meant for cookbooks, not
chef version numbers.  For Chef version numbers, `Gem::Version` should
be used.

Without this fix, I was getting errors for all knife commands:

```
/opt/chefdk/embedded/apps/chef/lib/chef/version_class.rb:65:in `parse': '11.18.0.rc.1' does not match 'x.y.z' or 'x.y' (Chef::Exceptions::InvalidCookbookVersion)
        from /opt/chefdk/embedded/apps/chef/lib/chef/version_class.rb:24:in `initialize'
        from /Users/docwhat/.chefdk/gem/ruby/2.1.0/gems/knife-inspect-0.11.0/lib/health_inspector/checklists/cookbooks.rb:4:in `new'
        from /Users/docwhat/.chefdk/gem/ruby/2.1.0/gems/knife-inspect-0.11.0/lib/health_inspector/checklists/cookbooks.rb:4:in `<top (required)>'
        from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        from /Users/docwhat/.chefdk/gem/ruby/2.1.0/gems/knife-inspect-0.11.0/lib/health_inspector.rb:8:in `<top (required)>'
        from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:128:in `require'
        from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:128:in `rescue in require'
        from /opt/chefdk/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:39:in `require'
        from /Users/docwhat/.chefdk/gem/ruby/2.1.0/gems/knife-inspect-0.11.0/lib/chef/knife/cookbook_inspect.rb:2:in `<top (required)>'
        from /opt/chefdk/embedded/apps/chef/lib/chef/knife/core/subcommand_loader.rb:37:in `load'
        from /opt/chefdk/embedded/apps/chef/lib/chef/knife/core/subcommand_loader.rb:37:in `block in load_commands'
        from /opt/chefdk/embedded/apps/chef/lib/chef/knife/core/subcommand_loader.rb:37:in `each'
        from /opt/chefdk/embedded/apps/chef/lib/chef/knife/core/subcommand_loader.rb:37:in `load_commands'
        from /opt/chefdk/embedded/apps/chef/lib/chef/knife.rb:120:in `load_commands'
        from /opt/chefdk/embedded/apps/chef/lib/chef/knife.rb:168:in `run'
        from /opt/chefdk/embedded/apps/chef/lib/chef/application/knife.rb:139:in `run'
        from /opt/chefdk/embedded/apps/chef/bin/knife:25:in `<top (required)>'
        from /opt/chefdk/bin/knife:33:in `load'
        from /opt/chefdk/bin/knife:33:in `<main>'
```