### PR TITLE
Fix namespace

### DIFF
--- a/lib/chef/knife/cookbook_inspect.rb
+++ b/lib/chef/knife/cookbook_inspect.rb
@@ -4,9 +4,9 @@ require 'health_inspector'
 class Chef
   class Knife
     class CookbookInspect < Knife
-      include HealthInspector::Runner
+      include ::HealthInspector::Runner
 
-      checklist HealthInspector::Checklists::Cookbooks
+      checklist ::HealthInspector::Checklists::Cookbooks
       banner 'knife cookbook inspect [COOKBOOK] (options)'
     end
   end

--- a/lib/chef/knife/data_bag_inspect.rb
+++ b/lib/chef/knife/data_bag_inspect.rb
@@ -17,20 +17,20 @@ class Chef
           bag_name  = @name_args[0]
           item_name = @name_args[1]
 
-          validator = HealthInspector::Checklists::DataBagItems.new(self)
+          validator = ::HealthInspector::Checklists::DataBagItems.new(self)
           item = validator.load_item("#{bag_name}/#{item_name}")
           exit validator.validate_item item
 
         when 1 # We are inspecting a data bag
           bag_name = @name_args[0]
 
-          validator = HealthInspector::Checklists::DataBags.new(self)
+          validator = ::HealthInspector::Checklists::DataBags.new(self)
           item = validator.load_item(bag_name)
           exit validator.validate_item item
 
         when 0 # We are inspecting all the data bags
-          exit HealthInspector::Checklists::DataBags.run(self) &&
-               HealthInspector::Checklists::DataBagItems.run(self)
+          exit ::HealthInspector::Checklists::DataBags.run(self) &&
+               ::HealthInspector::Checklists::DataBagItems.run(self)
         end
       end
     end

--- a/lib/chef/knife/data_bag_inspect.rb
+++ b/lib/chef/knife/data_bag_inspect.rb
@@ -1,14 +1,9 @@
 require 'chef/knife'
+require 'health_inspector'
 
 class Chef
   class Knife
     class DataBagInspect < Knife
-      # :nocov:
-      deps do
-        require 'health_inspector'
-      end
-      # :nocov:
-
       banner 'knife data bag inspect [BAG] [ITEM] (options)'
 
       def run

--- a/lib/chef/knife/environment_inspect.rb
+++ b/lib/chef/knife/environment_inspect.rb
@@ -4,9 +4,9 @@ require 'health_inspector'
 class Chef
   class Knife
     class EnvironmentInspect < Knife
-      include HealthInspector::Runner
+      include ::HealthInspector::Runner
 
-      checklist HealthInspector::Checklists::Environments
+      checklist ::HealthInspector::Checklists::Environments
       banner 'knife environment inspect [ENVIRONMENT] (options)'
     end
   end

--- a/lib/chef/knife/inspect.rb
+++ b/lib/chef/knife/inspect.rb
@@ -14,7 +14,7 @@ class Chef
       banner 'knife inspect'
 
       CHECKLISTS.each do |checklist|
-        checklist = HealthInspector::Checklists.const_get(checklist)
+        checklist = ::HealthInspector::Checklists.const_get(checklist)
 
         option checklist.option,
           :long => "--[no-]#{checklist.option}",
@@ -25,7 +25,7 @@ class Chef
 
       def run
         results = checklists_to_run.map do |checklist|
-          HealthInspector::Checklists.const_get(checklist).run(self)
+          ::HealthInspector::Checklists.const_get(checklist).run(self)
         end
 
         exit !results.include?(false)
@@ -35,7 +35,7 @@ class Chef
 
       def checklists_to_run
         CHECKLISTS.select do |checklist|
-          checklist = HealthInspector::Checklists.const_get(checklist)
+          checklist = ::HealthInspector::Checklists.const_get(checklist)
 
           config[checklist.option]
         end

--- a/lib/chef/knife/inspect.rb
+++ b/lib/chef/knife/inspect.rb
@@ -1,15 +1,10 @@
 require 'chef/knife'
+require 'health_inspector'
 
 class Chef
   class Knife
     class Inspect < Knife
       CHECKLISTS = %w(Cookbooks DataBags DataBagItems Environments Roles)
-
-      # :nocov:
-      deps do
-        require 'health_inspector'
-      end
-      # :nocov:
 
       banner 'knife inspect'
 

--- a/lib/chef/knife/role_inspect.rb
+++ b/lib/chef/knife/role_inspect.rb
@@ -4,9 +4,9 @@ require 'health_inspector'
 class Chef
   class Knife
     class RoleInspect < Knife
-      include HealthInspector::Runner
+      include ::HealthInspector::Runner
 
-      checklist HealthInspector::Checklists::Roles
+      checklist ::HealthInspector::Checklists::Roles
       banner 'knife role inspect [ROLE] (options)'
     end
   end


### PR DESCRIPTION
I've been getting this error when running knife-inspect in a Docker container (based on the ruby:2.2 image)

```
NameError: uninitialized constant Chef::Knife::Inspect::HealthInspector
```

I haven't been able to reproduce this outside of a Docker container. I do not know what is causing this but explicitly adding a root prefix to `HealthInspector` makes sense