### PR TITLE
Relax rack version requirement

### DIFF
--- a/knife-inspect.gemspec
+++ b/knife-inspect.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0.8'
 
   s.add_runtime_dependency 'chef',      chef_version
-  s.add_runtime_dependency 'rack',      '< 2'
+  s.add_runtime_dependency 'rack',      '~> 2'
   s.add_runtime_dependency 'parallel',  '~> 1.3'
   s.add_runtime_dependency 'inflecto',  '~> 0.0.2'
 end


### PR DESCRIPTION
This requirement stops knife-inspect working on the most recent chef-client omnibus installs, and as far as I can tell relaxing it doesn't break anything...