### PR TITLE
New feature: check local files in a cookbook that are not on the Chef server

### DIFF
--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -78,7 +78,9 @@ module HealthInspector
         begin
           # Cast local (Chef::Version) into a string
           cookbook_loader = Chef::Cookbook::CookbookVersionLoader.new(cookbook_path)
-          cookbook_loader.load
+          unless Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0')
+            cookbook_loader.load!
+	  end
           local_cookbook = cookbook_loader.cookbook_version
 
           remote_cookbook = Chef::CookbookVersion.load(name, local.to_s)

--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -78,7 +78,7 @@ module HealthInspector
         begin
           # Cast local (Chef::Version) into a string
           cookbook_loader = Chef::Cookbook::CookbookVersionLoader.new(cookbook_path)
-          cookbook_loader.load!
+          cookbook_loader.load
           local_cookbook = cookbook_loader.cookbook_version
 
           remote_cookbook = Chef::CookbookVersion.load(name, local.to_s)

--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -1,6 +1,7 @@
 require 'chef/version'
 require 'chef/cookbook_version'
 require 'chef/cookbook_loader'
+require 'chef/digester'
 require 'chef/checksum_cache' if Gem::Version.new(Chef::VERSION) < Gem::Version.new('11.0.0')
 
 module HealthInspector

--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -78,9 +78,7 @@ module HealthInspector
         begin
           # Cast local (Chef::Version) into a string
           cookbook_loader = Chef::Cookbook::CookbookVersionLoader.new(cookbook_path)
-          unless Gem::Version.new(Chef::VERSION) < Gem::Version.new('12.0.0')
-            cookbook_loader.load!
-	  end
+          cookbook_loader.load_cookbooks
           local_cookbook = cookbook_loader.cookbook_version
 
           remote_cookbook = Chef::CookbookVersion.load(name, local.to_s)

--- a/lib/health_inspector/checklists/cookbooks.rb
+++ b/lib/health_inspector/checklists/cookbooks.rb
@@ -33,7 +33,6 @@ module HealthInspector
         end
       end
 
-      # TODO: Check files that exist locally but not in manifest on server
       def validate_changes_on_the_server_not_in_the_repo
         return unless versions_exist? && versions_match?
 
@@ -103,18 +102,14 @@ module HealthInspector
             local_manifest_records.each do |local_manifest_record|
               local_path = local_manifest_record['path']
               remote_manifest_record = remote_manifest_records.find { |r| r['path'] == local_path }
-              unless remote_manifest_record.nil?
-                messages << "#{local_path}" if local_manifest_record['checksum'] != remote_manifest_record['checksum']
-              else
+              if remote_manifest_record.nil?
                 messages << "#{local_path} does not exist on the server"
               end
             end
           end
 
           unless messages.empty?
-            message = "has a checksum mismatch between server and repo in\n"
-            message << messages.map { |f| "    #{f}" }.join("\n")
-            errors.add message
+            errors.add messages.map { |m| "  #{m}" }.join("\n")
           end
 
         rescue Net::HTTPServerException

--- a/spec/health_inspector/checklists/cookbook_spec.rb
+++ b/spec/health_inspector/checklists/cookbook_spec.rb
@@ -34,15 +34,29 @@ RSpec.describe HealthInspector::Checklists::Cookbook do
 
   it 'detects if an item is the same' do
     cookbook_version = double('Chef::CookbookVersion')
-    allow(cookbook_version).to receive(:files_for).with(:attributes).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:definitions).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:files).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:libraries).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:providers).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:recipes).and_return([{ "path" => "recipes/default.rb", "checksum" => "d41d8cd98f00b204e9800998ecf8427e" }])
-    allow(cookbook_version).to receive(:files_for).with(:root_files).and_return([{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}])
-    allow(cookbook_version).to receive(:files_for).with(:resources).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:templates).and_return([])
+    if Gem::Version.new(Chef::VERSION) < Gem::Version.new('13.0.0')
+      allow(cookbook_version).to receive(:manifest).and_return({
+        attributes: [],
+        definitions: [],
+        files: [],
+        libraries: [],
+        providers: [],
+        recipes: [{ "path" => "recipes/default.rb", "checksum" => "d41d8cd98f00b204e9800998ecf8427e" }],
+        root_files: [{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}],
+        resources: [],
+        templates: []
+      })
+    else
+      allow(cookbook_version).to receive(:files_for).with(:attributes).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:definitions).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:files).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:libraries).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:providers).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:recipes).and_return([{ "path" => "recipes/default.rb", "checksum" => "d41d8cd98f00b204e9800998ecf8427e" }])
+      allow(cookbook_version).to receive(:files_for).with(:root_files).and_return([{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}])
+      allow(cookbook_version).to receive(:files_for).with(:resources).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:templates).and_return([])
+    end
     expect(Chef::CookbookVersion).to receive(:load)
       .with('cookbook_one', '0.0.1')
       .and_return(
@@ -58,15 +72,30 @@ RSpec.describe HealthInspector::Checklists::Cookbook do
 
   it 'detects if an item is not on the server' do
     cookbook_version = double('Chef::CookbookVersion')
-    allow(cookbook_version).to receive(:files_for).with(:attributes).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:definitions).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:files).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:libraries).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:providers).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:recipes).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:root_files).and_return([{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}])
-    allow(cookbook_version).to receive(:files_for).with(:resources).and_return([])
-    allow(cookbook_version).to receive(:files_for).with(:templates).and_return([])
+
+    if Gem::Version.new(Chef::VERSION) < Gem::Version.new('13.0.0')
+      allow(cookbook_version).to receive(:manifest).and_return({
+        attributes: [],
+        definitions: [],
+        files: [],
+        libraries: [],
+        providers: [],
+        recipes: [],
+        root_files: [{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}],
+        resources: [],
+        templates: []
+      })
+    else
+      allow(cookbook_version).to receive(:files_for).with(:attributes).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:definitions).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:files).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:libraries).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:providers).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:recipes).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:root_files).and_return([{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}])
+      allow(cookbook_version).to receive(:files_for).with(:resources).and_return([])
+      allow(cookbook_version).to receive(:files_for).with(:templates).and_return([])
+    end
     expect(Chef::CookbookVersion).to receive(:load)
       .with('cookbook_one', '0.0.1')
       .and_return(

--- a/spec/health_inspector/checklists/cookbook_spec.rb
+++ b/spec/health_inspector/checklists/cookbook_spec.rb
@@ -107,6 +107,6 @@ RSpec.describe HealthInspector::Checklists::Cookbook do
     pairing.validate
 
     expect(pairing.errors).not_to be_empty
-    expect(pairing.errors.first).to eq("has a checksum mismatch between server and repo in\n    recipes/default.rb does not exist on the server")
+    expect(pairing.errors.first).to eq("  recipes/default.rb does not exist on the server")
   end
 end

--- a/spec/health_inspector/checklists/cookbook_spec.rb
+++ b/spec/health_inspector/checklists/cookbook_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe HealthInspector::Checklists::Cookbook do
   let(:pairing) do
-    described_class.new(health_inspector_context, :name => 'dummy')
+    described_class.new(health_inspector_context, :name => 'cookbook_one')
   end
 
   it 'detects if an item does not exist locally' do
@@ -33,11 +33,51 @@ RSpec.describe HealthInspector::Checklists::Cookbook do
   end
 
   it 'detects if an item is the same' do
+    cookbook_version = double('Chef::CookbookVersion')
+    allow(cookbook_version).to receive(:files_for).with(:attributes).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:definitions).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:files).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:libraries).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:providers).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:recipes).and_return([{ "path" => "recipes/default.rb", "checksum" => "d41d8cd98f00b204e9800998ecf8427e" }])
+    allow(cookbook_version).to receive(:files_for).with(:root_files).and_return([{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}])
+    allow(cookbook_version).to receive(:files_for).with(:resources).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:templates).and_return([])
+    expect(Chef::CookbookVersion).to receive(:load)
+      .with('cookbook_one', '0.0.1')
+      .and_return(
+        cookbook_version
+    )
     expect(pairing).to receive(:validate_changes_on_the_server_not_in_the_repo)
     pairing.server = '0.0.1'
     pairing.local  = '0.0.1'
     pairing.validate
 
     expect(pairing.errors).to be_empty
+  end
+
+  it 'detects if an item is not on the server' do
+    cookbook_version = double('Chef::CookbookVersion')
+    allow(cookbook_version).to receive(:files_for).with(:attributes).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:definitions).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:files).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:libraries).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:providers).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:recipes).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:root_files).and_return([{"path" => "metadata.rb", "checksum" => "feaa135db12fdc37c3cd155d16f80b5f"}])
+    allow(cookbook_version).to receive(:files_for).with(:resources).and_return([])
+    allow(cookbook_version).to receive(:files_for).with(:templates).and_return([])
+    expect(Chef::CookbookVersion).to receive(:load)
+      .with('cookbook_one', '0.0.1')
+      .and_return(
+        cookbook_version
+    )
+    expect(pairing).to receive(:validate_changes_on_the_server_not_in_the_repo)
+    pairing.server = '0.0.1'
+    pairing.local  = '0.0.1'
+    pairing.validate
+
+    expect(pairing.errors).not_to be_empty
+    expect(pairing.errors.first).to eq("has a checksum mismatch between server and repo in\n    recipes/default.rb does not exist on the server")
   end
 end


### PR DESCRIPTION
I have found out that we did not check for local files in a cookbook that were not on the Chef server

This should work with Chef 11, 12 and 13 (we're using Chef 13 at the moment and are using this branch against our Chef server)